### PR TITLE
adição do editorconfig para padronização dos editores de código

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+ 
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+ 
+[*.md]
+insert_final_newline = false
+trim_trailing_whitespace = false


### PR DESCRIPTION
O arquivo editorconfig permite que nossos editores possuam as mesmas configurações para identação, espaços e etc.